### PR TITLE
Added devcontainer and initial Dockerfile

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,4 @@
+FROM rust:latest
+
+# To compile Hyper-Gen:
+#    cargo install --path . --root ~/.cargo

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,5 @@
+{
+  "build": {
+    "dockerfile": "Dockerfile"
+  }
+}


### PR DESCRIPTION
This way, developers can simply clone this repo in VS Code or open a GitHub Codespace, and the development environment will be set up automatically